### PR TITLE
Organized pointcloud params

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,13 +56,19 @@ ros2 launch rotating_lidar_accumulator accumulator_conf1.launch.py
 
 | Parameter Name                   | Description                                         | Default Value                     |
 |----------------------------------|-----------------------------------------------------|-----------------------------------|
-| `mech.lidar_offset_xyz_m`        | LiDAR positional offset in meters (x, y, z).       | `[0.0, 0.0, 0.0]`                |
-| `mech.lidar_offset_ypr_deg`      | LiDAR orientation offset in degrees (yaw, pitch, roll). | `[0.0, 0.0, 0.0]`            |
-| `mech.rotation_axis`             | Axis of rotation for the LiDAR (x, y, z).          | `[0.0, 1.0, 0.0]`                |
-| `pointcloud.topic.out`           | Name of the output topic.                           | `/pointcloud`                |
-| `pointcloud.ordered`             | Generate organized point clouds (true/false).      | `false`                          |
-| `pointcloud.lidar_angular_res_deg` | Angular resolution of the 2D LiDAR in degrees.    | `0.225`                          |
-| `pointcloud.max_num_layers`      | Maximum number of scan layers.              | `200`                            |
+| `mech.lidar_offset_xyz_m`        | LiDAR positional offset in meters (x, y, z).       | `[0.0, 0.0, 0.0]`|
+| `mech.lidar_offset_ypr_deg`      | LiDAR orientation offset in degrees (yaw, pitch, roll). | `[0.0, 0.0, 0.0]`|
+| `mech.rotation_axis`             | Axis of rotation for the LiDAR (x, y, z).          | `[0.0, 1.0, 0.0]`|
+| `pointcloud.topic.out`           | Name of the output topic.                           | `/pointcloud`|
+| `pointcloud.frame_id`           | Name of the frame id of the output pointcloud.                           | `lidar_base`|
+| `pointcloud.max_num_layers`      | Maximum number of scan layers that can be accumulated.              | `200`|
+| `pointcloud.organized`             | Generate organized point clouds (true/false).      | `false`|
+| `pointcloud.azimuth.res_deg` | Azimuth angular resolution of the organized pointcloud in degrees.    | `0.225`|
+| `pointcloud.azimuth.fov_deg` | Azimuth Field of View (FOV) of the organized pointcloud in degrees.    | `360.0`|
+| `pointcloud.azimuth.min_deg` | Starting angle of the Azimuth FOV of the organized pointcloud in degrees.    | `-180.0`|
+| `pointcloud.elevation.res_deg` | Elevation angular resolution of the organized pointcloud in degrees.    | `1.0`|
+| `pointcloud.elevation.fov_deg` | Elevation Field of View (FOV) of the organized pointcloud in degrees.    | `30.0`|
+| `pointcloud.elevation.min_deg` | Starting angle of the Elevation FOV of the organized pointcloud in degrees.    | `-15.0`|
 
 ## Topics
 

--- a/config/conf0.yaml
+++ b/config/conf0.yaml
@@ -14,8 +14,16 @@ point_cloud_accumulator:
         - 0.0
         - -1.0
     pointcloud:
-      enable_ordered: true
-      lidar_res_deg: 0.0225
       max_num_layers: 200
       topic:
         out: "/points"
+      frame_id: "lidar_base"
+      enable_organized: true
+      azimuth:
+        res_deg: 0.225
+        fov_deg: 360.0
+        min_deg: -180.0
+      elevation:
+        res_deg: 1.0
+        fov_deg: 30.0
+        min_deg: -15.0

--- a/config/conf1.yaml
+++ b/config/conf1.yaml
@@ -14,8 +14,16 @@ point_cloud_accumulator:
         - 0.0
         - 0.0
     pointcloud:
-      enable_ordered: false
-      lidar_res_deg: 0.0225
       max_num_layers: 200
       topic:
         out: "/points"
+      frame_id: "lidar_base"
+      enable_organized: true
+      azimuth:
+        res_deg: 0.225
+        fov_deg: 360.0
+        min_deg: -180.0
+      elevation:
+        res_deg: 1.0
+        fov_deg: 30.0
+        min_deg: -15.0

--- a/include/rotating_lidar_accumulator/conversion.cpp
+++ b/include/rotating_lidar_accumulator/conversion.cpp
@@ -51,8 +51,8 @@ sensor_msgs::msg::PointCloud2 organizePointCloud2(
 {
 
     // Define organized cloud dimensions
-    int width = static_cast<int>(std::round(params.h_fov_rad / params.h_res_rad));
-    int height = static_cast<int>(std::round(params.v_fov_rad / params.v_res_rad));
+    int width = static_cast<int>(std::round(params.azim_fov_rad / params.azim_res_rad));
+    int height = static_cast<int>(std::round(params.elev_fov_rad / params.elev_res_rad));
 
     // Initialize the organized PointCloud2 message
     sensor_msgs::msg::PointCloud2 organized_cloud;
@@ -118,10 +118,10 @@ int calculatePointCol(const pcl::PointXYZI& point,
     const PointCloudOrganizationParams& params)
 {
     // Calculate azimuth angle in rad and corresponding column index
-    float azimuth_rad = std::atan2(point.y, point.x);
-    float azimuth_delta_rad = azimuth_rad - params.h_min_rad;
+    float azim_rad = std::atan2(point.y, point.x);
+    float azim_delta_rad = azim_rad - params.azim_min_rad;
 
-    int col = static_cast<int>(std::floor(azimuth_delta_rad / params.h_res_rad));
+    int col = static_cast<int>(std::floor(azim_delta_rad / params.azim_res_rad));
     return col;
 }
 
@@ -129,10 +129,10 @@ int calculatePointRow(const pcl::PointXYZI& point,
     const PointCloudOrganizationParams& params)
 {
     // Calculate corresponding row index
-    float elevation_rad = std::asin(point.z / std::sqrt(point.x * point.x + point.y * point.y + point.z * point.z));
-    float elevation_delta_rad = elevation_rad - params.v_min_rad;
+    float elev_rad = std::asin(point.z / std::sqrt(point.x * point.x + point.y * point.y + point.z * point.z));
+    float elev_delta_rad = elev_rad - params.elev_min_rad;
 
-    int row = static_cast<int>(std::floor(elevation_delta_rad / params.v_res_rad));
+    int row = static_cast<int>(std::floor(elev_delta_rad / params.elev_res_rad));
     return row;
 }
 

--- a/include/rotating_lidar_accumulator/conversion.h
+++ b/include/rotating_lidar_accumulator/conversion.h
@@ -10,12 +10,12 @@
 #include <sensor_msgs/point_cloud2_iterator.hpp>
 
 struct PointCloudOrganizationParams {
-    float h_fov_rad = 0.0f;
-    float h_res_rad = 0.0f;
-    float h_min_rad = 0.0f;
-    float v_fov_rad = 0.0f;
-    float v_res_rad = 0.0f;
-    float v_min_rad = 0.0f;
+    float azim_fov_rad = 0.0f;
+    float azim_res_rad = 0.0f;
+    float azim_min_rad = 0.0f;
+    float elev_fov_rad = 0.0f;
+    float elev_res_rad = 0.0f;
+    float elev_min_rad = 0.0f;
 };
 
 pcl::PointCloud<pcl::PointXYZI>::Ptr convertLaserScanToPointCloud(

--- a/include/rotating_lidar_accumulator/point_cloud_buffer.h
+++ b/include/rotating_lidar_accumulator/point_cloud_buffer.h
@@ -29,9 +29,10 @@ public:
     void addScan(const sensor_msgs::msg::LaserScan& scan, float angle_rad);
     void addScan(ScanLayer&& scan);
     void reset();
+    void enableOrganizedPointcloud(const PointCloudOrganizationParams& p);
+    void disableOrganizedPointcloud();
     pcl::PointCloud<pcl::PointXYZI>::Ptr getTotalPointcloud();
     sensor_msgs::msg::PointCloud2 getTotalPointcloudROS();
-    sensor_msgs::msg::PointCloud2 getTotalOrganizedPointcloudROS();
     pcl::PointCloud<pcl::PointXYZI>::Ptr getScan(int index);
     unsigned int getNumLayers() const {return scans_.size();}
     unsigned int getCurrentIndex() const {return idx_;}
@@ -47,6 +48,7 @@ private:
     std::vector<ScanLayer> scans_;
     PointCloudOrganizationParams organized_params_;
     unsigned int idx_;
+    bool enable_organize_ = false;
 };
 
 


### PR DESCRIPTION
- Add as ROS params the parameters used to organize the pointcloud, and frame id of the output pointcloud.
- Update documentation.
- Change some names. Important the change from horizontal (`h`) to azimuth (`azim`), and vertical (`v`) to elevation (`elev`).
- Change ownership of variable for enabling organized pointcloud.